### PR TITLE
Fix dark background of search stream items

### DIFF
--- a/less/tweet-dark.less
+++ b/less/tweet-dark.less
@@ -16,3 +16,7 @@
 .stream-item:hover {
 	background-color:	@tweet-dark-hover;
 }
+
+.js-search-in-popover .stream-item:hover {
+	background-color:	@tweet-hover;
+}


### PR DESCRIPTION
On the dark theme, if you hover over a stream item in the search dialogue, the background turns dark and the text becomes almost impossible to read. This stops that from happening by making it the colour it would be on hover if it were the _light_ theme (which is the styling for that piece anyway)
